### PR TITLE
[PAK]: Add Utilities To Read And Write PAK (ZIP) Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "24.2.0",
     "@types/prompts": "2.4.9",
+    "@types/yauzl": "2.10.3",
     "@typescript-eslint/parser": "8.39.0",
     "@vitest/ui": "3.2.4",
     "eslint": "9.32.0",
@@ -54,6 +55,7 @@
     "conf": "14.0.0",
     "i18next": "25.3.2",
     "i18next-fs-backend": "2.6.0",
-    "prompts": "2.4.2"
+    "prompts": "2.4.2",
+    "yauzl": "3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/node": "24.2.0",
     "@types/prompts": "2.4.9",
     "@types/yauzl": "2.10.3",
+    "@types/yazl": "3.3.0",
     "@typescript-eslint/parser": "8.39.0",
     "@vitest/ui": "3.2.4",
     "eslint": "9.32.0",
@@ -56,6 +57,7 @@
     "i18next": "25.3.2",
     "i18next-fs-backend": "2.6.0",
     "prompts": "2.4.2",
-    "yauzl": "3.2.0"
+    "yauzl": "3.2.0",
+    "yazl": "3.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       prompts:
         specifier: 2.4.2
         version: 2.4.2
+      yauzl:
+        specifier: 3.2.0
+        version: 3.2.0
     devDependencies:
       '@eslint/js':
         specifier: 9.32.0
@@ -39,6 +42,9 @@ importers:
       '@types/prompts':
         specifier: 2.4.9
         version: 2.4.9
+      '@types/yauzl':
+        specifier: 2.10.3
+        version: 2.10.3
       '@typescript-eslint/parser':
         specifier: 8.39.0
         version: 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
@@ -556,6 +562,9 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@typescript-eslint/eslint-plugin@8.39.0':
     resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -759,6 +768,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1255,6 +1267,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1584,6 +1599,10 @@ packages:
 
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  yauzl@3.2.0:
+    resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
     engines: {node: '>=12'}
 
   yn@3.1.1:
@@ -1935,6 +1954,10 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 24.2.0
+
   '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -2198,6 +2221,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-crc32@0.2.13: {}
 
   cac@6.7.14: {}
 
@@ -2697,6 +2722,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pend@1.2.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -3015,6 +3042,11 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+
+  yauzl@3.2.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   yn@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       yauzl:
         specifier: 3.2.0
         version: 3.2.0
+      yazl:
+        specifier: 3.3.1
+        version: 3.3.1
     devDependencies:
       '@eslint/js':
         specifier: 9.32.0
@@ -45,6 +48,9 @@ importers:
       '@types/yauzl':
         specifier: 2.10.3
         version: 2.10.3
+      '@types/yazl':
+        specifier: 3.3.0
+        version: 3.3.0
       '@typescript-eslint/parser':
         specifier: 8.39.0
         version: 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
@@ -565,6 +571,9 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
+  '@types/yazl@3.3.0':
+    resolution: {integrity: sha512-mFL6lGkk2N5u5nIxpNV/K5LW3qVSbxhJrMxYGOOxZndWxMgCamr/iCsq/1t9kd8pEwhuNP91LC5qZm/qS9pOEw==}
+
   '@typescript-eslint/eslint-plugin@8.39.0':
     resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -771,6 +780,10 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1605,6 +1618,9 @@ packages:
     resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
     engines: {node: '>=12'}
 
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -1958,6 +1974,10 @@ snapshots:
     dependencies:
       '@types/node': 24.2.0
 
+  '@types/yazl@3.3.0':
+    dependencies:
+      '@types/node': 24.2.0
+
   '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -2223,6 +2243,8 @@ snapshots:
       fill-range: 7.1.1
 
   buffer-crc32@0.2.13: {}
+
+  buffer-crc32@1.0.0: {}
 
   cac@6.7.14: {}
 
@@ -3047,6 +3069,10 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       pend: 1.2.0
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yn@3.1.1: {}
 

--- a/src/utils/pakUtils.ts
+++ b/src/utils/pakUtils.ts
@@ -1,0 +1,92 @@
+import path from 'path';
+import yauzl, { Entry, ZipFile } from 'yauzl';
+
+import { LocalizationFile } from '../constants/constants.ts';
+
+/**
+ * Reads the content of a single ZIP entry as UTF-8 text.
+ *
+ * @param {Entry} entry - The zip entry to process.
+ * @param {ZipFile} zipFile - The opened zip file that contains the entries.
+ * @returns {Promise<string>} Resolves with the entry's text content (UTF-8).
+ *
+ * @throws Will reject if the entry stream cannot be opened or if a stream error occurs.
+ */
+const processEntry = (entry: Entry, zipFile: ZipFile): Promise<string> =>
+  new Promise((resolve, reject) => {
+    zipFile.openReadStream(entry, (error, readStream) => {
+      if (error || !readStream) {
+        reject(error);
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+
+      readStream.on('data', (chunk) => chunks.push(chunk));
+      readStream.on('end', () => {
+        const content = Buffer.concat(chunks).toString('utf8');
+        resolve(content);
+      });
+      readStream.on('error', reject);
+    });
+  });
+
+/**
+ * Reads an XML file from within a PAK (ZIP) archive.
+ *
+ * Iterates through the PAK entries until the requested XML file is found,
+ * then extracts and returns its contents as UTF-8 text.
+ *
+ * @param {string} pakPath - Full path to the `.pak` file (ZIP archive).
+ * @param {LocalizationFile} xmlFileName - The name of the XML file to extract.
+ * @returns {Promise<string>} Resolves with the XML file content if found.
+ *
+ * @throws Will reject if:
+ *   - The PAK file cannot be opened.
+ *   - The target XML file is not found inside the archive.
+ *   - An error occurs while reading the entry stream.
+ */
+export const readXmlFromPak = (
+  pakPath: string,
+  xmlFileName: LocalizationFile,
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    // NOTE: `lazyEntries` indicates that entries should be read only when readEntry() is called.
+    yauzl.open(pakPath, { lazyEntries: true }, (err, zipFile) => {
+      if (err || !zipFile) {
+        reject(err ?? new Error('Failed to open package file'));
+        return;
+      }
+
+      let isTargetFile = false;
+
+      zipFile.readEntry();
+
+      zipFile.on('entry', async (entry: Entry) => {
+        isTargetFile = entry.fileName === xmlFileName;
+
+        if (isTargetFile) {
+          try {
+            const content = await processEntry(entry, zipFile);
+            resolve(content);
+          } catch (error) {
+            reject(error);
+          }
+        } else {
+          zipFile.readEntry();
+        }
+      });
+
+      zipFile.on('end', () => {
+        zipFile.close();
+
+        if (!isTargetFile) {
+          reject(
+            new Error(
+              `❌ File "${xmlFileName}" not found in path "${pakPath}".`,
+            ),
+          );
+        }
+      });
+    });
+  });


### PR DESCRIPTION
- Added `writePak` to create PAK archives from a list of files, with optional folder structure inside the archive.
- Added `readXmlFromPak` to read specific XML localization files from a PAK archive.
- Introduced `processEntry` and `readFileFromZip` helpers to handle zip entry streams with error handling.